### PR TITLE
Fix QEMU build script for arm config

### DIFF
--- a/Chapter04/build-linux-versatilepb.sh
+++ b/Chapter04/build-linux-versatilepb.sh
@@ -8,7 +8,7 @@ if [ $? != 0 ]; then echo "ERROR"; exit; fi
 make ARCH=arm CROSS_COMPILE=arm-unknown-linux-gnueabi- mrproper
 if [ $? != 0 ]; then echo "ERROR"; exit; fi
 
-make versatile_defconfig
+make ARCH=arm versatile_defconfig
 if [ $? != 0 ]; then echo "ERROR"; exit; fi
 
 make -j4 ARCH=arm CROSS_COMPILE=arm-unknown-linux-gnueabi- zImage


### PR DESCRIPTION
Build script for QEMU kernel fails on x86 build hosts because ARCH is not set for defconfig

```*** Can't find default configuration "arch/x86/configs/versatile_defconfig"!```

Set ARCH=arm to keep continuity and pass build. 
   
Signed-off-by: Shawn Doherty <shawnpdoherty@pm.me>